### PR TITLE
Fix docs search

### DIFF
--- a/source/_themes/valodoc/layout.html
+++ b/source/_themes/valodoc/layout.html
@@ -10,19 +10,11 @@
 {%- endif %}
 
 {%- macro script() %}
-    <script type="text/javascript">
-      var DOCUMENTATION_OPTIONS = {
-        URL_ROOT: '{{ url_root }}',
-        VERSION: '{{ release|e }}',
-        COLLAPSE_INDEX: false,
-        FILE_SUFFIX: '{{ '' if no_search_suffix else file_suffix }}',
-        HAS_SOURCE:  {{ has_source|lower }},
-        SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
-      };
-    </script>
+    <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {%- for scriptfile in script_files %}
-        <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+        {{ js_tag(scriptfile) }}
     {%- endfor %}
+    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
 {%- endmacro %}
 
 {%- macro css() %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -9,7 +9,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('.'))
 
-needs_sphinx = '1.5'
+needs_sphinx = '1.8'
 
 extensions = [
     'sphinx.ext.intersphinx',


### PR DESCRIPTION
Fixes #30

With sphinx 1.8 came a new way to define scripts and JS document options so switched to that.

For reasons I didn't dwell too deep into, search tools were not included either after this change so added that that fixes the search.