### PR TITLE
Document Valohai's IP Address

### DIFF
--- a/source/guides/private-bitbucket-repository.rst
+++ b/source/guides/private-bitbucket-repository.rst
@@ -18,6 +18,7 @@ For this tutorial you will need:
 * a private Bitbucket repository
 * a Valohai project which to link the repository
 * a tool that generates SSH keys, this guide uses :code:`ssh-keygen`
+* access from Valohai (IP address: 34.248.245.191) through your firewall to your private Bitbucket
 
 2. Generate an SSH key pair
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/guides/private-github-repository.rst
+++ b/source/guides/private-github-repository.rst
@@ -20,6 +20,7 @@ For this tutorial you will need:
 * a private GitHub repository
 * a Valohai project which to link the repository
 * a tool that generates SSH keys, this guide uses :code:`ssh-keygen`
+* access from Valohai (IP address: 34.248.245.191) through your firewall to your private GitHub
 
 .. tip::
 

--- a/source/guides/private-gitlab-repository.rst
+++ b/source/guides/private-gitlab-repository.rst
@@ -18,6 +18,7 @@ For this tutorial you will need:
 * a private GitLab repository
 * a Valohai project which to link the repository
 * a tool that generates SSH keys, this guide uses :code:`ssh-keygen`
+* access from Valohai (IP address: 34.248.245.191) through your firewall to your private GitLab
 
 2. Generate an SSH key pair
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Private git/bitbucket installations need to open firewalls for Valohai. Documented the IP address that needs to be opened for private github/gitlab/bitbucket installations.