### PR TITLE
Use our fork of sphinx-click

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
+-e git+https://github.com/valohai/sphinx-click.git@escape-fix#egg=sphinx-click
 awscli
 sphinx
 sphinx-autobuild
-sphinx-click
 sphinx-sitemap
 sphinxcontrib-images
 valohai-cli

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile requirements.in
 #
+-e git+https://github.com/valohai/sphinx-click.git@escape-fix#egg=sphinx-click
 alabaster==0.7.12         # via sphinx
 argh==0.26.2              # via sphinx-autobuild, watchdog
 attrs==19.3.0             # via jsonschema
@@ -28,7 +29,7 @@ markupsafe==1.1.1         # via jinja2
 more-itertools==8.1.0     # via zipp
 packaging==19.2           # via sphinx
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
-pbr==5.4.4                # via sphinx-click
+pbr==5.4.4
 port_for==0.3.1           # via sphinx-autobuild
 pyasn1==0.4.8             # via rsa
 pycparser==2.19           # via cffi
@@ -46,7 +47,6 @@ s3transfer==0.2.1         # via awscli
 six==1.13.0               # via cryptography, jsonschema, livereload, packaging, pyopenssl, pyrsistent, python-dateutil, sphinx, sphinx-sitemap, valohai-cli
 snowballstemmer==2.0.0    # via sphinx
 sphinx-autobuild==0.7.1
-sphinx-click==2.3.1
 sphinx-sitemap==1.1.0
 sphinx==1.8.5
 sphinxcontrib-images==0.8.0

--- a/source/conf.py
+++ b/source/conf.py
@@ -25,29 +25,6 @@ templates_path = [
     '_templates',
 ]
 
-# <FILTHY-HACK>
-import sphinx_click.ext
-
-
-def i_feel_so_filthy(opt):
-    # This fixes a bug in sphinx-click/docutils combo that cause improper escaping of
-    # backticks (`) in click documentation that trigger the following warning from docutils RST parser.
-    # "WARNING: Inline interpreted text or phrase reference start-string without end-string."
-    # TODO: clean and make a proper PR sometime
-    opt = sphinx_click.ext._get_help_record(opt)
-
-    yield '.. option:: {}'.format(opt[0])
-    if opt[1]:
-        yield ''
-        from docutils import statemachine
-        for line in statemachine.string2lines(opt[1], tab_width=4, convert_whitespace=True):
-            line = line.replace('`', '\\`')  # THE ONLY CHANGE <=
-            yield sphinx_click.ext._indent(line)
-
-
-sphinx_click.ext._format_option = i_feel_so_filthy
-# </FILTHY-HACK>
-
 site_url = 'https://docs.valohai.com/'
 source_suffix = ['.rst', '.md']
 master_doc = 'index'


### PR DESCRIPTION
The hack has been ported into https://github.com/valohai/sphinx-click/commit/8bda92e5d6c53d2370785b58fc04e4e5df618830 – things seem to compile without warnings, so I made a PR upstream: https://github.com/click-contrib/sphinx-click/pull/57