### PR TITLE
Private docker, endpoint testing and requirements.txt in deployments

### DIFF
--- a/source/core-concepts/deployments.rst
+++ b/source/core-concepts/deployments.rst
@@ -83,3 +83,10 @@ Alias
 Aliases create canonical URLs for development so you can use Valohai to control which version is being served in each context. This allows you to update currently used version or rollback to previous version if something goes wrong.
 
 For example, version alias ``https://valohai.cloud/ruksi/mnist/americas/production/predict-digit`` could be used by applications utilizing your predictions and they don't need to change the URL when you a release new version.
+
+Testing an endpoint
+~~~~~~~~~~~~~~~~~~~~
+
+You can easily test your endpoint by sending it a POST/GET/PUT request with a query and/or fields. A field could be for example a JSON-file or an image.
+
+Navigate inside a deployment select the endpoint, define your request and press *Send*. You'll get the response from your inference service directly in your browser.

--- a/source/core-concepts/deployments.rst
+++ b/source/core-concepts/deployments.rst
@@ -87,6 +87,8 @@ For example, version alias ``https://valohai.cloud/ruksi/mnist/americas/producti
 Testing an endpoint
 ~~~~~~~~~~~~~~~~~~~~
 
-You can easily test your endpoint by sending it a POST/GET/PUT request with a query and/or fields. A field could be for example a JSON-file or an image.
+You can easily test your endpoint by sending it a POST/GET/PUT request with a query and/or fields.
+A field could be e.g. plain text, a JSON file or an image.
 
-Navigate inside a deployment select the endpoint, define your request and press *Send*. You'll get the response from your inference service directly in your browser.
+Navigate inside a deployment, select the endpoint, define your request and press *Send*.
+You'll get the response from your inference service directly in your browser.

--- a/source/docker-images.rst
+++ b/source/docker-images.rst
@@ -21,3 +21,19 @@ Which images to use depend on your specific use-case, but it usually makes sense
 
 * start with as minimal image as possible
 * use a specific image tag (the ``:<VERSION>`` part) so everything stays reproducible
+
+Access Private Docker Repositories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Organizations can use private repositories from Docker Hub or Azure Container Registry for Valohai executions.
+
+Create an `Access token on Docker Hub <https://docs.docker.com/docker-hub/access-tokens/>`_ or a `service principal for Azure Container Registry <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-auth-service-principal>`_ to generate credentials that Valohai can use to access your private repository.
+
+1. Login at `<https://app.valohai.com>`_
+2. Navigate to ``Hi, <name> (the top right menu) > Manage <organization>``. 
+3. Go to *Registries* under the organization controls
+4. Add a new entry
+5. Insert the name in the format of *docker.io/myusername/** or *myregistry.azurecr.io/**.
+6. Use the previously generated credentials as the username and password (Docker username and access token or Azure Service Principal credentials)
+
+To use a private Docker image in your executions specify the image in the step of your ``valohai.yaml`` using the full name like ``docker.io/myusername/name:tag``.

--- a/source/valohai-yaml/endpoint/server-command/index.rst
+++ b/source/valohai-yaml/endpoint/server-command/index.rst
@@ -24,3 +24,5 @@
           - name: model
             description: Model output file from TensorFlow
             path: model.pb
+
+Valohai runs automatically ``pip install --disable-pip-version-check --no-cache-dir --user -r requirements.txt`` in case you have additional dependencies defined in *requirements.txt*. You'll then be able run commands from the installed packages from ``~/.local/bin``

--- a/source/valohai-yaml/endpoint/server-command/index.rst
+++ b/source/valohai-yaml/endpoint/server-command/index.rst
@@ -25,4 +25,5 @@
             description: Model output file from TensorFlow
             path: model.pb
 
-Valohai runs automatically ``pip install --disable-pip-version-check --no-cache-dir --user -r requirements.txt`` in case you have additional dependencies defined in *requirements.txt*. You'll then be able run commands from the installed packages from ``~/.local/bin``
+Valohai automatically runs ``pip install --user -r requirements.txt`` in case you have additional dependencies defined in *requirements.txt* in your project root.
+Commands from installed packages end up in ``~/.local/bin``, following the standards for ``pip --user`` installation.


### PR DESCRIPTION
Added private docker description, a note that there is an deployment endpoint testing available and that VH installs automatically requirements.txt with deployments