### PR TITLE
Add GetBucketLocation to suggested IAM roles for custom S3 stores

### DIFF
--- a/source/howto/data/cloud-storage/private-s3-bucket/index.rst
+++ b/source/howto/data/cloud-storage/private-s3-bucket/index.rst
@@ -188,6 +188,7 @@ Create a new AWS IAM **Role**. The role policy document should look like:
                "Effect": "Allow",
                "Action": [
                    "s3:AbortMultipartUpload",
+                   "s3:GetBucketLocation",
                    "s3:GetObject",
                    "s3:ListBucket",
                    "s3:ListBucketMultipartUploads",


### PR DESCRIPTION
We need this to verify the bucket location and fail if it's incorrect; if we don't have the permission, the check will silently fail.