### PR TITLE
Fix indents in pipelines in 101 tutorial

### DIFF
--- a/source/tutorials/quickstart/quickstart-pipeline.rst
+++ b/source/tutorials/quickstart/quickstart-pipeline.rst
@@ -85,18 +85,18 @@ Create **one edge** to connect the nodes:
               path: model.h5
 
     - pipeline:
-      name: Train and deploy
-      nodes:
-        - name: train-node
-          type: execution
-          step: train-model
-        - name: deploy-node
-          type: deployment
-          deployment: mydeployment
-          endpoints:
-            - digits
-      edges:
-        - [train-node.output.model.h5, deploy-node.file.digits.model]
+        name: Train and deploy
+        nodes:
+          - name: train-node
+            type: execution
+            step: train-model
+          - name: deploy-node
+            type: deployment
+            deployment: mydeployment
+            endpoints:
+              - digits
+        edges:
+          - [train-node.output.model.h5, deploy-node.file.digits.model]
 
 ..
 


### PR DESCRIPTION
Code example for yaml file in the pipelines section for 101 tutorial had wrong indents (only the added pipeline) and this resulted in an error. Fixed this to reduce confusion. 