### PR TITLE
Valohai-utils topic guide (fixes #137)

### DIFF
--- a/source/howto/new-user-guide/code/data.rst
+++ b/source/howto/new-user-guide/code/data.rst
@@ -159,3 +159,7 @@ All files that are saved to ``/valohai/outputs/`` will automatically get version
     * `Upload files mid-execution </topic-guides/executions/live-outputs/>`_
     * `Trace modes and data files </topic-guides/reproducibility.html#trace-models-and-data-files>`_
     * `Mount a network file system (NFS) </howto/data/mount-nfs.html>`_ 
+
+.. hint:: 
+
+    `Read more about valohai-utils </topic-guides/valohai-utils/>`_

--- a/source/howto/new-user-guide/code/metadata.rst
+++ b/source/howto/new-user-guide/code/metadata.rst
@@ -67,3 +67,7 @@ Collecting metadata from a Valohai execution allows you to easily sort, filter, 
     * `Creating visualizations </topic-guides/executions/metadata/>`_
     * `Compare executions </howto/executions/compare/>`_
     * `Save graphs from executions </howto/executions/complex-visualizations/>`_
+
+.. hint:: 
+
+    `Read more about valohai-utils </topic-guides/valohai-utils/>`_

--- a/source/howto/new-user-guide/code/parameters.rst
+++ b/source/howto/new-user-guide/code/parameters.rst
@@ -106,3 +106,7 @@ Using parameters allows you to:
 .. seealso::
 
     * `More about parameters </topic-guides/core-concepts/parameters/>`_
+
+.. hint:: 
+
+    `Read more about valohai-utils </topic-guides/valohai-utils/>`_

--- a/source/reference-guides/valohai-cli/index.rst
+++ b/source/reference-guides/valohai-cli/index.rst
@@ -1,6 +1,9 @@
 .. meta::
     :description: Command listing for the Valohai command-line client
 
+.. _cli:
+
+
 Command-line Reference
 ======================
 

--- a/source/topic-guides/index.rst
+++ b/source/topic-guides/index.rst
@@ -17,6 +17,7 @@ Topic guides discuss key topics and concepts at a fairly high level and provide 
     architecture/index
     reproducibility
     setup/index
+    valohai-utils/index
 
 
 "So, what *is* Valohai?"

--- a/source/topic-guides/valohai-utils/index.rst
+++ b/source/topic-guides/valohai-utils/index.rst
@@ -1,0 +1,82 @@
+.. meta::
+    :description: A Python toolkit for the everyday Valohai boilerplate.
+
+.. _valohai-utils:
+
+Valohai-utils Python Toolkit
+============================
+
+One of the Valohai core design principles is to be an unopinionated agnostic platform. The user is not forced to use
+any specific programming language, framework or SDK.
+
+That said, Valohai offers a Python utility library called
+``valohai-utils`` to help with the everyday boilerplate.
+
+.. tip::
+
+    This is an in-depth topic guide. If you are just starting out, check the :ref:`learning-paths-fundamentals` first.
+
+
+Installation
+------------
+
+.. code-block:: bash
+
+    pip install valohai-utils
+
+Example Usage
+-------------
+
+train.py
+########
+
+.. code-block:: python
+
+    import valohai
+
+
+    params = {
+        "iterations": 10,
+        "learning-rate": 0.001,
+    }
+
+    inputs = {
+        "train": "http://example.com/training_set.zip",
+        "test": "http://example.com/test_set.zip",
+    }
+
+    valohai.prepare(step="train", default_parameters=params, default_inputs=inputs)
+
+    for i in valohai.parameters("iterations").value:
+        for path in valohai.inputs("train").paths():
+            print(path)
+
+
+What is it?
+-----------
+
+The ``valohai-utils`` is a generic utility library for the Valohai user. In general, it streamlines pipeline definition and writing Valohai-compatible code. This is achieved by offering utility functions for the most common tasks, which are all described in the sections below.
+
+The library is designed to be used hand-in-hand with the `Valohai CLI </reference-guides/valohai-cli>`_. User can update the valohai YAML configuration based on ``valohai-utils`` powered code using the CLI commands ``vh yaml step`` and ``vh yaml pipeline``.
+
+What it isn't?
+---------------
+
+The ``valohai-utils`` library is not a machine learning or data science library. It helps in OS-level tasks like figuring out the input file paths or parsing the command-line parameters. It does not tune hyperparameters or train a model.
+
+
+.. toctree::
+    :titlesonly:
+
+    prepare()
+    parameters
+    inputs
+    outputs
+    logging
+
+
+
+
+
+
+

--- a/source/topic-guides/valohai-utils/index.rst
+++ b/source/topic-guides/valohai-utils/index.rst
@@ -6,7 +6,7 @@
 Valohai-utils Python Toolkit
 ============================
 
-One of the Valohai core design principles is to be an unopinionated agnostic platform. The user is not forced to use
+One of the Valohai core design principles is to be an unopinionated agnostic platform. The user is not required to use
 any specific programming language, framework or SDK.
 
 That said, Valohai offers a Python utility library called
@@ -57,7 +57,9 @@ What is it?
 
 The ``valohai-utils`` is a generic utility library for the Valohai user. In general, it streamlines pipeline definition and writing Valohai-compatible code. This is achieved by offering utility functions for the most common tasks, which are all described in the sections below.
 
-The library is designed to be used hand-in-hand with the `Valohai CLI </reference-guides/valohai-cli>`_. User can update the valohai YAML configuration based on ``valohai-utils`` powered code using the CLI commands ``vh yaml step`` and ``vh yaml pipeline``.
+The library is designed to be used hand-in-hand with the `Valohai CLI </reference-guides/valohai-cli>`_. 
+
+You can generate or update an existing :ref:`yaml` using the command ``vh yaml step <filename>`` and ``vh yaml pipeline <filename>``.
 
 What it isn't?
 ---------------
@@ -68,7 +70,7 @@ The ``valohai-utils`` library is not a machine learning or data science library.
 .. toctree::
     :titlesonly:
 
-    prepare()
+    prepare
     parameters
     inputs
     outputs

--- a/source/topic-guides/valohai-utils/inputs.rst
+++ b/source/topic-guides/valohai-utils/inputs.rst
@@ -7,7 +7,7 @@ Inputs
 To get some data for your :doc:`step </topic-guides/core-concepts/steps>`, you need :doc:`inputs </reference-guides/valohai-yaml/step-inputs>`.
 Inputs are basically the required files that are expected to be there when the code is executed.
 
-With ``valohai-utils``, you define the inputs in the call to the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method.
+With ``valohai-utils``, you define the inputs in the call to the :doc:`prepare </topic-guides/valohai-utils/prepare>` method.
 Feed the ``default_inputs`` argument with a key/value dictionary of the inputs.
 
 * **key** is the name of the input in the configuration YAML and in the Valohai UI.
@@ -58,7 +58,7 @@ This key/value pair...
       default: https://example.com/images.zip
       optional: false
 
-.. note::
+.. hint::
 
     Empty default value signals an  **optional** input.
 
@@ -77,10 +77,10 @@ This key/value pair...
 Accessing input files
 ---------------------
 
-Once you have defined an input using the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method, you can access
+Once you have defined an input using the :doc:`prepare </topic-guides/valohai-utils/prepare>` method, you can access
 the files by referring to the input name.
 
-In Valohai, input is not a single file. It can be multiple URIs. And it doesn't end there.
+In Valohai, an input is not always A single file. It can be multiple URIs. And it doesn't end there.
 Each of those URIs may actually represent multiple files on multiple folders. And some of those files may actually
 be zip archives with multiple files and folders in them!
 
@@ -90,9 +90,9 @@ handles most of this complexity for you.
 Use the ``.path()``, ``.paths()``, ``.stream()``, ``.streams()`` methods to access files of a single input.
 
 Single file
------------
+-------------
 
-When you are always expecting a single file, use ``.path()``.
+If you're expecting a single file in your inputs, you can simply use ``.path()``.
 
 .. code-block:: python
 
@@ -243,7 +243,7 @@ You can also override the default with the command-line. See the next section.
 Overriding input URIs
 ---------------------
 
-Inputs defined by the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` often have a default value.
+Inputs defined by the :doc:`prepare </topic-guides/valohai-utils/prepare>` often have a default value.
 
 There are two ways to override the default (or empty) value:
 
@@ -266,3 +266,9 @@ Example (remote):
 
     vh yaml step train.py
     vh exec run -a train --images==https://alternative.com/images.zip
+
+.. seealso::
+
+    * `step.inputs </reference-guides/valohai-yaml/step-inputs/>`_
+    * `Data aliases </howto/data/datum-alias.html>`_
+    * `Add your own cloud data store </howto/data/cloud-storage/>`_

--- a/source/topic-guides/valohai-utils/inputs.rst
+++ b/source/topic-guides/valohai-utils/inputs.rst
@@ -1,0 +1,268 @@
+.. meta::
+    :description: Defining inputs with valohai-utils.
+
+Inputs
+======
+
+To get some data for your :doc:`step </topic-guides/core-concepts/steps>`, you need :doc:`inputs </reference-guides/valohai-yaml/step-inputs>`.
+Inputs are basically the required files that are expected to be there when the code is executed.
+
+With ``valohai-utils``, you define the inputs in the call to the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method.
+Feed the ``default_inputs`` argument with a key/value dictionary of the inputs.
+
+* **key** is the name of the input in the configuration YAML and in the Valohai UI.
+* **value** defines the default uri of the input and also the type.
+
+Defining inputs with ``valohai-utils`` solves these problems:
+
+* Handling different input variations (single file, multiple files, archived files)
+* Uncompressing archived files on-demand
+* Filtering a subset of the input
+* Downloading the inputs for local runs
+* Parsing the command-line overrides
+* Managing the duplicate definitions between Python & YAML
+
+train.py
+--------
+
+Here we define a :doc:`step </topic-guides/core-concepts/steps>` ``train``,
+with an :doc:`input </topic-guides/core-concepts/parameters>` ``training-images``.
+
+.. code-block:: python
+
+    import valohai
+
+
+    inputs = {
+        "training-images": "https://example.com/images.zip",
+    }
+
+    valohai.prepare(
+        step="train",
+        default_inputs=inputs,
+    )
+
+This key/value pair...
+
+.. code-block:: python
+
+    inputs = {
+        "training-images": "https://example.com/images.zip",
+    }
+
+...will be transpiled into the following YAML
+
+.. code-block:: yaml
+
+    - name: training-images
+      default: https://example.com/images.zip
+      optional: false
+
+.. note::
+
+    Empty default value signals an  **optional** input.
+
+    .. code-block:: python
+
+        inputs = {
+            "extra-images": "",
+        }
+
+
+    .. code-block:: yaml
+
+        - name: extra-images
+          optional: true
+
+Accessing input files
+---------------------
+
+Once you have defined an input using the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method, you can access
+the files by referring to the input name.
+
+In Valohai, input is not a single file. It can be multiple URIs. And it doesn't end there.
+Each of those URIs may actually represent multiple files on multiple folders. And some of those files may actually
+be zip archives with multiple files and folders in them!
+
+In other words, handling a Valohai input robustly is not as simple as it sounds. Luckily ``valohai-utils``
+handles most of this complexity for you.
+
+Use the ``.path()``, ``.paths()``, ``.stream()``, ``.streams()`` methods to access files of a single input.
+
+Single file
+-----------
+
+When you are always expecting a single file, use ``.path()``.
+
+.. code-block:: python
+
+    import json
+    import valohai
+
+    inputs = {
+        "my-config": "",
+    }
+
+    valohai.prepare(
+        step="train",
+        default_inputs=inputs,
+    )
+
+    with open(valohai.inputs("my-config").path()) as f:
+        data = json.load(f)
+
+
+Alternatively you can also use ``.stream()``
+
+.. code-block:: python
+
+    data = json.load(valohai.inputs("my-config").stream())
+
+
+Even when you are always expecting a single file, your colleagues might still accidentally feed your input with
+several files!
+
+In that case, ``.path()`` or ``.stream()`` returns the first file it encounters, which can be brittle.
+
+To be more explicit about the input, you can do this:
+
+.. code-block:: python
+
+    with open(valohai.inputs("my-config").path("*.json")) as f:
+        data = json.load(f)
+
+Or to be fully explicit
+
+.. code-block:: python
+
+    with open(valohai.inputs("my-config").path("config.json")) as f:
+        data = json.load(f)
+
+
+Multiple files
+--------------
+
+When handling an input with multiple files, you want to use ``.paths()`` or ``.streams()``
+
+.. code-block:: python
+
+    import valohai
+
+    inputs = {
+        "images": "https://example.com/images.zip",
+    }
+
+    valohai.prepare(
+        step="train",
+        default_inputs=inputs,
+    )
+
+    for image_path in valohai.inputs("images").paths():
+        # Do something per image
+
+The beauty of ``.paths()`` or ``.streams()`` is that the code above will handle all of these different input scenarios:
+
+* Single ``my-image.jpg``
+* Multiple images ``my-image1.jpg``, ``my-image2.jpg``, ``myimage-3.jpg``
+* ``my-images.zip`` containing multiple images
+* Multiple archives ``my-images1.zip``, ``my-images2.zip``, ``my-images3.zip``
+* Hybrid mix of all the above
+
+There is no longer need to write separate handler for each scenario, as ``valohai-utils`` is taking care of everything.
+All you need to do is iterate over paths of an input.
+
+
+Archives
+--------
+
+Archive files are automatically uncompressed under the hood when you are using ``.paths()`` and friends. Currently supported archive types are ``tar`` and ``zip``.
+
+It is worth pointing out that the archives are not prematurely uncompressed to the disk.
+
+The library is smart and uncompresses files on-demand. When you iterate over the
+contents of a huge archive, each file is uncompressed one-by-one and the potential errors are raised immediately.
+
+Sometimes you might want to specifically handle or uncompress the archives yourself, though.
+
+In that case, you can set the ``process_archives=false``
+which signals ``valohai-utils`` to not automatically uncompress the contents of archives, but return paths to the actual archive
+files instead.
+
+.. code-block:: python
+
+
+    for image_path in valohai.inputs("zipped_images").paths():
+        print(image_path) # image1.jpg, image2.jpg, image3.jpeg...
+
+    for archive_path in valohai.inputs("zipped_images").paths(process_archives=false):
+        print(archive_path) # images.zip
+
+Filtering
+---------
+
+When you have multiple files in multiple folders as an input, you sometimes need only a subset.
+
+All the four methods ``path()``, ``stream()``, ``paths()``, ``streams()`` support a wildcard filter.
+
+Here are some examples of how to use the filter:
+
+.. code-block:: python
+
+    valohai.inputs("images").paths()
+    valohai.inputs("images").paths("*.jpg")
+    valohai.inputs("images").paths("dog_*.jpg")
+    valohai.inputs("images").paths("training-set/*.jpg")
+    valohai.inputs("images").paths("images/**/dogs/*.jpg")
+
+Downloading
+-----------
+
+When you run your code remotely as an execution in the Valohai platform, all the downloading of the inputs is done by the platform.
+
+When you run your code locally, the platform is not there to help. Instead, ``valohai-utils`` downloads the files from
+the input URIs for you.
+
+The files are placed in the automatically generated ``.valohai/inputs/{step_name}/{input_name}`` subfolder.
+
+When the code is re-executed, the library doesn't try to download the files again, but uses the cached ones from the disk.
+You can force the re-downloading by simply deleting the folder from the disk.
+
+You can also create the ``.valohai/inputs/{step_name}/{input_name}`` folder manually and place some files in it, if you
+just want to use local files as an input instead downloading from an URI.
+
+Another alternative is to temporarily use a local default for an input:
+
+.. code-block:: python
+
+    inputs = {
+        "images": "/tmp/images.zip",
+    }
+
+You can also override the default with the command-line. See the next section.
+
+Overriding input URIs
+---------------------
+
+Inputs defined by the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` often have a default value.
+
+There are two ways to override the default (or empty) value:
+
+* Command-line parameter (local)
+* Valohai UI or CLI (remote)
+
+Example (local):
+
+.. code-block:: bash
+
+    python train.py --images==/tmp/images.zip
+
+.. code-block:: bash
+
+    python train.py --images==https://alternative.com/images.zip
+
+Example (remote):
+
+.. code-block:: bash
+
+    vh yaml step train.py
+    vh exec run -a train --images==https://alternative.com/images.zip

--- a/source/topic-guides/valohai-utils/logging.rst
+++ b/source/topic-guides/valohai-utils/logging.rst
@@ -1,0 +1,38 @@
+.. meta::
+    :description: Logging with valohai-utils.
+
+Logging
+=======
+
+When your training code is running on the Valohai platform, it is a good idea to store some metadata
+or metrics for the model training performance.
+
+Everything you ``print()`` during a remote execution is collected and stored by Valohai as raw logs.
+
+To save the explicitly tracked metrics -- the execution metadata -- you need to print them out as a JSON object.
+
+The ``valohai-utils`` custom logger automatically handles the grouping of the metrics into a single JSON object.
+
+.. code-block:: python
+
+    import valohai
+
+    for i in range(3):
+        with valohai.metadata.logger() as logger:
+            logger.log("iteration", i)
+            logger.log("accuracy", 0.001)
+            logger.log("loss", 12.456)
+
+This example would print:
+
+.. code-block:: Python
+
+    {"iteration": 0, "accuracy": 0.001, "loss": 12.456}
+    {"iteration": 1, "accuracy": 0.001, "loss": 12.456}
+    {"iteration": 2, "accuracy": 0.001, "loss": 12.456}
+
+It is important to use the ``with`` block so that the logger knows how to group the metrics of a single iteration.
+
+The metrics of a single ``iteration``, ``epoch`` or similar, need to be grouped into
+a single JSON object printout. If printed out as separated objects, the platform doesn't understand
+them as a meaningful set.

--- a/source/topic-guides/valohai-utils/logging.rst
+++ b/source/topic-guides/valohai-utils/logging.rst
@@ -36,3 +36,8 @@ It is important to use the ``with`` block so that the logger knows how to group 
 The metrics of a single ``iteration``, ``epoch`` or similar, need to be grouped into
 a single JSON object printout. If printed out as separated objects, the platform doesn't understand
 them as a meaningful set.
+
+.. seealso::
+
+    * `Compare executions </howto/executions/compare/>`_
+    * `Save graphs from executions </howto/executions/complex-visualizations/>`_

--- a/source/topic-guides/valohai-utils/outputs.rst
+++ b/source/topic-guides/valohai-utils/outputs.rst
@@ -1,0 +1,131 @@
+.. meta::
+    :description: Defining outputs with valohai-utils.
+
+Outputs
+=======
+
+Once your code has trained a model or preprocessed a dataset, it is time to output something.
+
+An output is a collection of files, which is you consider worth saving and are sent back to the
+data store by the Valohai platform.
+
+You choose your output files by putting them in a special folder ``/valohai/outputs/{output_name}``.
+Luckily ``valohai-utils`` makes this a bit easier.
+
+Saving outputs with ``valohai-utils`` helps with these problems:
+
+* Differences between local and remote execution
+* Compressing outputs to a single archive
+* Live upload
+
+Saving an Output
+----------------
+
+Saving an output with ``valohai-utils`` is easy. You ask for a correct path from the library and save the file there.
+The library creates the output folder automatically for you, if it already doesn't exists.
+
+For example a step that resizes a single image, would look like this:
+
+.. code-block:: python
+
+    import valohai
+
+    # Open the image
+    image = Image.open(valohai.inputs('image').path())
+
+    # Resize the image
+    new_image = image.resize((width, height))
+
+    # Query an output path for the filename "resized_image.png"
+    out_path = valohai.outputs().path('resized_image.png')
+
+    # Save the file to the output path
+    new_image.save(out_path)
+
+Outputs can also have names, which are basically subfolders. It is a good idea to use naming and not output everything
+into the output root folder.
+
+.. code-block:: python
+
+    out_path = valohai.outputs("my-output").path('resized_image.png')
+    print(out_path)  # my-output/resized_image.png
+
+When building pipelines, you feed output(s) of one step as the input(s) of another, so
+clearly naming your outputs will make your pipelines more explicit and robust.
+
+Compressing Outputs
+-------------------
+
+It is often desired to archive the outputs. Not only do you save some space and get a quicker upload, but simply having a single
+archive instead of 200,000 separate files is a lot easier to manage.
+
+Let's say we have a step that resizes every ``.png`` file in the ``images`` input.
+
+Here is an example of saving the resized images as a single archived output file (``resized/images.zip``).
+
+.. code-block:: python
+
+    import valohai
+
+    for image_path in valohai.inputs('images').paths("*.png"):
+        image = Image.open(image_path)
+        new_image = image.resize((width, height))
+        out_path = valohai.outputs("resized").path(f"resized_{os.path.basename(image_path)}")
+        new_image.save(out_path)
+
+    valohai.outputs('resized').compress("*.png", "images.zip")
+
+By default, the original ``.png`` files are removed and just the archive is saved.
+If you want to save **both** the original files and the archive, you can set the ``remove_originals`` to ``false``.
+
+.. code-block:: python
+
+    valohai.outputs('resized').compress("*.png", "images.zip", remove_originals=false)
+
+
+Live Outputs
+------------
+
+During a remote execution, Valohai waits for the execution to finish and only uploads the outputs afterwards.
+
+That said, you often want to upload your outputs right away and not wait for the entire step
+to finish. In this case you can use the live uploading feature.
+
+The way to request for a live upload is to call the ``live_upload()`` method. It sets
+the file as read-only, which signals to the Valohai platform that this file can be uploaded immediately.
+
+.. code-block:: python
+
+    # Query an output path for the filename "resized_image.png"
+    out_path = valohai.outputs().path("resized_image.png")
+
+    # Save the file to the output path
+    new_image.save(out_path)
+
+    # Request for an immediate upload
+    valohai.outputs().live_upload("resized_image.png")
+
+    # Carry on doing something else...
+
+Local and Remote
+----------------
+
+When your code is executed remotely in the Valohai platform, the outputs are put into a special
+folder, which Valohai then sends them onward to the data store.
+
+When your code is executed and debugged locally, you don't want things to be sent anywhere, but you
+do want them to be saved to the hard disk.
+
+When you call ``valohai.outputs("my-output")``, the library knows whether the code is running locally or remotely
+and chooses the correct folder.
+
+This is where the file will end up under the hood:
+
+* Local execution: ``.valohai/outputs/{hash}/my-output``
+* Remote execution: ``/valohai/outputs/my-output``
+
+For each local run, a new ``{hash}`` is generated. The hash starts with a timestamp to make the latest outputs easier to find.
+
+.. note::
+
+    If you want to override the target folder for local or remote execution, set the ``VH_OUTPUTS_DIR`` environment variable.

--- a/source/topic-guides/valohai-utils/outputs.rst
+++ b/source/topic-guides/valohai-utils/outputs.rst
@@ -129,3 +129,7 @@ For each local run, a new ``{hash}`` is generated. The hash starts with a timest
 .. note::
 
     If you want to override the target folder for local or remote execution, set the ``VH_OUTPUTS_DIR`` environment variable.
+
+.. seealso::
+
+    * `Reproducibility and lineage </topic-guides/reproducibility/>`_

--- a/source/topic-guides/valohai-utils/parameters.rst
+++ b/source/topic-guides/valohai-utils/parameters.rst
@@ -1,0 +1,92 @@
+.. meta::
+    :description: Defining parameters with valohai-utils.
+
+Parameters
+==========
+
+To parameterize a :doc:`step </topic-guides/core-concepts/steps>`, you need :doc:`parameters </topic-guides/core-concepts/parameters>`. They can be ``float``, ``integer``, ``string`` or ``boolean`` type.
+
+With ``valohai-utils``, you define the parameters in the call to the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method. Feed the ``default_parameters`` argument with a key/value dictionary of the parameters.
+
+* **key** is the name of the parameter. Used in the code, the YAML and the Valohai UI.
+* **value** defines the default value of the parameter and also it's type.
+
+.. note::
+
+    Empty values are not supported as they have no type.
+
+Defining parameters with ``valohai-utils`` solves two problems:
+
+* Parsing the command-line overrides
+* Managing the duplicate definitions between Python & YAML
+
+train.py
+--------
+
+Here we define a :doc:`step </topic-guides/core-concepts/steps>` ``train``,
+with a :doc:`parameter </topic-guides/core-concepts/parameters>` ``learning-rate``.
+
+.. code-block:: python
+
+    import valohai
+
+
+    params = {
+        "learning-rate": 0.001,
+    }
+
+    valohai.prepare(
+        step="train",
+        default_parameters=params,
+    )
+
+This key/value pair...
+
+.. code-block:: python
+
+    params = {
+        "learning-rate": 0.001
+    }
+
+...will be transpiled into the following YAML
+
+.. code-block:: yaml
+
+    - name: learning-rate
+      default: 0.001
+      optional: false
+      type: float
+
+Accessing values
+----------------
+
+Once you have defined a parameter using the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method, you can access it in your code
+by referring to the parameter name.
+
+.. code-block:: python
+
+    lr = valohai.parameters("learning-rate").value
+
+
+Overriding values
+-----------------
+
+All parameters defined by the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method always have a default value.
+
+There are two ways to override the default value:
+
+* Command-line parameter (local)
+* Valohai UI or CLI (remote)
+
+Example (local):
+
+.. code-block:: bash
+
+    python train.py --learning-rate=.002
+
+Example (remote):
+
+.. code-block:: bash
+
+    vh yaml step train.py
+    vh exec run -a train --learning-rate=.002

--- a/source/topic-guides/valohai-utils/parameters.rst
+++ b/source/topic-guides/valohai-utils/parameters.rst
@@ -6,7 +6,7 @@ Parameters
 
 To parameterize a :doc:`step </topic-guides/core-concepts/steps>`, you need :doc:`parameters </topic-guides/core-concepts/parameters>`. They can be ``float``, ``integer``, ``string`` or ``boolean`` type.
 
-With ``valohai-utils``, you define the parameters in the call to the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method. Feed the ``default_parameters`` argument with a key/value dictionary of the parameters.
+With ``valohai-utils``, you define the parameters in the call to the :doc:`prepare </topic-guides/valohai-utils/prepare>` method. Feed the ``default_parameters`` argument with a key/value dictionary of the parameters.
 
 * **key** is the name of the parameter. Used in the code, the YAML and the Valohai UI.
 * **value** defines the default value of the parameter and also it's type.
@@ -60,7 +60,7 @@ This key/value pair...
 Accessing values
 ----------------
 
-Once you have defined a parameter using the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method, you can access it in your code
+Once you have defined a parameter using the :doc:`prepare </topic-guides/valohai-utils/prepare>` method, you can access it in your code
 by referring to the parameter name.
 
 .. code-block:: python
@@ -71,7 +71,7 @@ by referring to the parameter name.
 Overriding values
 -----------------
 
-All parameters defined by the :doc:`prepare() </topic-guides/valohai-utils/prepare()>` method always have a default value.
+All parameters defined by the :doc:`prepare </topic-guides/valohai-utils/prepare>` method always have a default value.
 
 There are two ways to override the default value:
 
@@ -90,3 +90,8 @@ Example (remote):
 
     vh yaml step train.py
     vh exec run -a train --learning-rate=.002
+
+.. seealso::
+
+    * `Running a Grid Search </howto/tasks/grid-search/>`_
+    * `Using the Bayesian Optimizer </howto/tasks/bayesian/>`_

--- a/source/topic-guides/valohai-utils/prepare().rst
+++ b/source/topic-guides/valohai-utils/prepare().rst
@@ -1,0 +1,159 @@
+.. meta::
+    :description: Explaining the valohai-utils prepare() method.
+
+valohai.prepare()
+=================
+
+In Valohai jargon, a :doc:`step </topic-guides/core-concepts/steps>` is a piece of code that performs a single operation like "train" or "preprocess".
+Calling the ``valohai.prepare()`` method defines a single step.
+
+Under the hood, Valohai steps are always defined in the `valohai.yaml </reference-guides/valohai-yaml>`_ config file. What ``valohai-utils``
+offers is a shortcut for defining the step in your Python code. Those steps can then be transpiled into
+corresponding YAML using the Valohai CLI.
+
+train.py
+----------------------------------------
+
+.. code-block:: python
+
+    import valohai
+
+
+    params = {
+        "learning-rate": 0.001,
+    }
+
+    inputs = {
+        "training-set": "http://example.com/training_set.zip",
+    }
+
+    valohai.prepare(
+        step="train",
+        default_parameters=params,
+        default_inputs=inputs,
+        image="tensorflow/tensorflow:gpu"
+    )
+
+Here we define a :doc:`step </topic-guides/core-concepts/steps>` ``train``,
+with a :doc:`parameter </topic-guides/core-concepts/parameters>` ``learning-rate``
+and an :doc:`input </reference-guides/valohai-yaml/step-inputs>` ``training-set``.
+
+We also define default values and a default Docker image
+``tensorflow/tensorflow:gpu``. The Docker image is used during remote execution on the Valohai platform.
+
+Valohai platform is agnostic and doesn't understand Python directly. It can only understand YAML and OS-level commands (bash). Thus, this step needs to be transpiled into YAML and bash using the Valohai command-line client.
+
+To update our YAML, we use the ``vh yaml step`` command.
+
+.. code-block:: bash
+
+    vh yaml step train.py
+
+valohai.yaml (generated)
+----------------------------------------
+
+.. code-block:: yaml
+
+    - step:
+        name: train
+        image: tensorflow/tensorflow:gpu
+        command:
+        - pip install -r requirements.txt
+        - python ./test.py {parameters}
+        parameters:
+        - name: learning-rate
+          default: 0.001
+          optional: false
+          type: float
+        inputs:
+        - name: training-set
+          default:
+          - http://example.com/training_set.zip
+          optional: false
+
+
+This solves two main issues:
+
+* Writing the YAML manually
+* Managing the duplicate definitions between Python & YAML
+
+What does the prepare() actually do?
+------------------------------------------
+
+The ``prepare()`` method has a dual purpose.
+
+1. Define a Valohai :doc:`step </topic-guides/core-concepts/steps>`
+2. Parse the command-line overrides
+
+1. Define a Valohai step
+----------------------------------------
+To define a step, the call to the ``prepare()`` method doesn't actually do anything. It just acts as a decorator.
+A decorator for what? A decorator for the ``vh yaml step`` command.
+
+When the ``vh yaml step train.py`` CLI command is executed, the ``train.py`` is parsed by the CLI program.
+
+.. note::
+
+	Parsing is not the same as executing!
+
+	Parsing here means that the parser parses through the source code file and looks for the call to the ``prepare()`` method.
+
+Once found, the parser grabs the step name, parameters, inputs and the Docker image. With this newly aquired information, the YAML
+representation of the step can be generated.
+
+This is why we call the ``prepare()`` method a decorator.
+
+.. note::
+
+    Because the parser doesn't execute the Python file - it simply parses it - you can't use variables for your definitions.
+
+    This works:
+
+    ``inputs = {"training-set": "http://example.com/training_set.zip"}``
+
+    This does **not** work:
+
+    ``inputs = {"training-set": f"http://{my_domain}/training_set.zip"}``
+
+    The value of ``my_domain`` variable is unknown to the parser and the parsing will fail.
+
+2. Parse the command-line overrides
+------------------------------------------------------------
+
+If the ``prepare()`` was simply a decorator, it would not do anything. But it actually does, because it
+has another purpose in life: Parsing the command-line overrides.
+
+If we use the ``prepare()``, we have the opportunity to override default values via command-line. **You can override
+both the parameters and the inputs** of a step.
+
+Let's say we have the ``train.py`` from our earlier example.
+
+.. code-block:: python
+
+    import valohai
+
+
+    params = {
+        "learning-rate": 0.001,
+    }
+
+    inputs = {
+        "training-set": "http://example.com/training_set.zip",
+    }
+
+    valohai.prepare(
+        step="train",
+        default_parameters=params,
+        default_inputs=inputs,
+        image="tensorflow/tensorflow:gpu"
+    )
+
+We can now override ``learning-rate`` and ``training-set``:
+
+.. code-block:: bash
+
+    python train.py --learning-rate=.002 --training-set=https://alt.com/training_set_2.zip
+
+This means that you don't need to go through the hassle of writing your custom parser for the command-line
+parameters. The ``prepare()`` method does that for you.
+

--- a/source/topic-guides/valohai-utils/prepare.rst
+++ b/source/topic-guides/valohai-utils/prepare.rst
@@ -5,7 +5,7 @@ valohai.prepare()
 =================
 
 In Valohai jargon, a :doc:`step </topic-guides/core-concepts/steps>` is a piece of code that performs a single operation like "train" or "preprocess".
-Calling the ``valohai.prepare()`` method defines a single step.
+A single step is defined by calling the ``valohai.prepare()`` method.
 
 Under the hood, Valohai steps are always defined in the `valohai.yaml </reference-guides/valohai-yaml>`_ config file. What ``valohai-utils``
 offers is a shortcut for defining the step in your Python code. Those steps can then be transpiled into
@@ -85,14 +85,14 @@ The ``prepare()`` method has a dual purpose.
 1. Define a Valohai :doc:`step </topic-guides/core-concepts/steps>`
 2. Parse the command-line overrides
 
-1. Define a Valohai step
+3. Define a Valohai step
 ----------------------------------------
 To define a step, the call to the ``prepare()`` method doesn't actually do anything. It just acts as a decorator.
 A decorator for what? A decorator for the ``vh yaml step`` command.
 
 When the ``vh yaml step train.py`` CLI command is executed, the ``train.py`` is parsed by the CLI program.
 
-.. note::
+.. important::
 
 	Parsing is not the same as executing!
 

--- a/source/tutorials/learning-paths/fundamentals/valohai-utils/index.rst
+++ b/source/tutorials/learning-paths/fundamentals/valohai-utils/index.rst
@@ -4,7 +4,7 @@
 valohai-utils (Python)
 #######################
 
-``valohai-utils`` is a Python helper library that makes it easier to configure and run Valohai executions.
+The valohai-utils is a generic utility library for the Valohai user. In general, it streamlines pipeline definition and writing Valohai-compatible code. This is achieved by offering utility functions for the most common tasks.
 
 **What does valohai-utils do?**
 
@@ -16,7 +16,9 @@ valohai-utils (Python)
 * Straightforward way to print metrics as Valohai metadata
 * Code parity between local vs. cloud
 
-Read more at https://github.com/valohai/valohai-utils
+.. seealso::
+
+    `Read more about valohai-utils </topic-guides/valohai-utils/>`_
 
 Install the tools
 -------------------


### PR DESCRIPTION
Explains all ins and outs of the `valohai-utils`.

Some duplication & redundancy with the existing documentation for sure, but can't be avoided.

Left out pipelines for now. Will come back to them later on.