### PR TITLE
Update the private worker setup instructions

### DIFF
--- a/source/howto/setup/aws_private_worker.rst
+++ b/source/howto/setup/aws_private_worker.rst
@@ -238,14 +238,19 @@ Create a VPC and subnets per each availability zone you want to use. For example
 
 📝 Record the subnet names.
 
+Create an internet gateway:
+
 * Internet Gateway
     * Name: `valohai-igw`
     * Tag: Key=valohai Value=1
     * **Attach** this Internet Gateway to `valohai-vpc`
 
-* Routing Table rename the default table of `valohai-vpc` to `valohai-rt`
+Rename the default routing table of `valohai-vpc`:
+
+* Routing Table
+    * **Rename** to `valohai-rt`
     * Tag: Key=valohai Value=1
-    * **Edit the routes:**
+    * **Edit** the routes:
         * 10.0.0.0/16 => local
         * 0.0.0.0/0 => `valohai-igw`
 
@@ -303,7 +308,7 @@ Tag the security group with Key=valohai Value=1.
 
 **EC2 Instance for the Worker Queue**
 
-Here we provision an Elastic IP and an EC2 instance for running the worker queue. The worker queue hosts a Redis server for passing jobs to workers and storing short-term logs.
+Next provision an Elastic IP and an EC2 instance for running the worker queue. The worker queue hosts a Redis server for passing jobs to workers and storing short-term logs.
 
 * EC2 instance
     * Name: `valohai-i-queue`

--- a/source/howto/setup/aws_private_worker.rst
+++ b/source/howto/setup/aws_private_worker.rst
@@ -47,10 +47,10 @@ This role is assigned to the individual EC2 instances to query information about
 Start by creating a policy that we'll attach to the role:
 
 * Open the AWS Console and navigate to `IAM -> Policies <https://console.aws.amazon.com/iam/home#/policies>`_
-* Click on **create policy**
+* Create policy
 * Paste the JSON from below as the new policy
 * Add a tag `valohai` with value `1`
-* Give the policy a name `ValohaiWorkerPolicy`
+* Name the policy `ValohaiWorkerPolicy`
 
 .. code-block:: json
 
@@ -74,12 +74,12 @@ Start by creating a policy that we'll attach to the role:
 
 **Create an IAM Role**
 
-* Open the AWS Console and navigate to `IAM -> Roles <https://console.aws.amazon.com/iam/home#/roles>`_
-* Create a new role called `ValohaiWorkerRole` 
+* Open the AWS Console and navigate to `IAM -> Roles <https://console.aws.amazon.com/iam/home#/roles>`_ 
 * Create role
 * Choose EC2 as the use case
 * Find and attach the `ValohaiWorkerPolicy` policy
 * Add a tag `valohai` with value `1`
+* Name the role `ValohaiWorkerRole`
 
 📝 Record the `ValohaiWorkerRole` ARN.
 
@@ -104,10 +104,10 @@ These are credentials allowing the Valohai web application at https://app.valoha
 Start by creating a policy that defines permissions for the role that Valohai can assume:
 
 * Open the AWS Console and navigate to `IAM -> Policies <https://console.aws.amazon.com/iam/home#/policies>`_
-* Click on **Create policy**
+* Create policy
 * Paste the JSON from below as the new policy
 * Add a tag `valohai` with value `1`
-* Give the policy a name `ValohaiMasterPolicy`
+* Name the policy `ValohaiMasterPolicy`
 
 .. admonition:: Important
     :class: warning
@@ -179,10 +179,11 @@ Start by creating a policy that defines permissions for the role that Valohai ca
 **Create an IAM Role**
 
 * Open the AWS Console and navigate to `IAM -> Roles <https://console.aws.amazon.com/iam/home#/roles>`_
-* Create a new role called `ValohaiMaster` 
+* Create role
 * Choose EC2 as the use case
 * Find and attach the `ValohaiMasterPolicy` policy
 * Add a tag `valohai` with value `1`
+* Name the role `ValohaiMaster`
 
 Once the role is created open the role's **Trust relationships** tab and click **Edit trust relationship**
 


### PR DESCRIPTION
Multiple updates:
- remove reference to plain Redis
- instruct to create a new Key Pair for the worker queue instance
- add valohai:1 tag to all created resources
- VPC ID should be recorded instead of VPC name
- make it clearer what needs to be recorded
- improve writing in general