### PR TITLE
Fix metadata Python example

### DIFF
--- a/source/howto/new-user-guide/code/metadata.rst
+++ b/source/howto/new-user-guide/code/metadata.rst
@@ -37,9 +37,11 @@ Collecting metadata from a Valohai execution allows you to easily sort, filter, 
         import json
 
         print()
-        print(json.dumps({"epoch": epoch})
-        print(json.dumps({"accuracy": accuracy})
-        print(json.dumps({"loss": loss})
+        print(json.dumps({
+            "epoch": epoch,
+            "accuracy": accuracy,
+            "loss": loss
+        }))
 
     ..
 


### PR DESCRIPTION
Every line of
```
print(json.dumps({"epoch": epoch})
print(json.dumps({"accuracy": accuracy})
print(json.dumps({"loss": loss})
```
were missing closing bracket. But it also sets a bad example how to make metadata so changed it to a single json-object to get proper outcome.