### PR TITLE
Update to Sphinx 4 and Furo 2021.11, use Python 3.10 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       PIP_EXISTS_ACTION: w
     docker:
-    - image: cimg/python:3.9.3-node
+    - image: cimg/python:3.10.1-node
     steps:
     - checkout
     - restore_cache:

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
-sphinx-click
-sphinx
+furo~=2021.11.23.0
 sphinx-autobuild
+sphinx-click
+sphinx-copybutton
+sphinx-inline-tabs
 sphinx-sitemap
+sphinx>=4.0
+sphinxcontrib-details-directive
 sphinxcontrib-images
 valohai-cli==0.16.0
-sphinx-copybutton
-furo==2021.4.11b34
-sphinx-inline-tabs
-sphinxcontrib-details-directive

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ beautifulsoup4==4.10.0
     # via furo
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.7
+charset-normalizer==2.0.9
     # via requests
 click==8.0.3
     # via
@@ -22,11 +22,11 @@ click==8.0.3
     #   valohai-cli
 colorama==0.4.4
     # via sphinx-autobuild
-docutils==0.16
+docutils==0.17.1
     # via
     #   sphinx
     #   sphinx-click
-furo==2021.4.11b34
+furo==2021.11.23
     # via -r requirements.in
 gitignorant==0.1.2
     # via valohai-cli
@@ -45,7 +45,9 @@ markupsafe==2.0.1
 packaging==21.3
     # via sphinx
 pygments==2.10.0
-    # via sphinx
+    # via
+    #   furo
+    #   sphinx
 pyparsing==3.0.6
     # via packaging
 pyrsistent==0.18.0
@@ -71,7 +73,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==3.5.4
+sphinx==4.3.1
     # via
     #   -r requirements.in
     #   furo
@@ -112,7 +114,7 @@ tornado==6.1
     # via livereload
 tqdm==4.62.3
     # via valohai-utils
-typing-extensions==4.0.0
+typing-extensions==4.0.1
     # via valohai-cli
 urllib3==1.26.7
     # via requests
@@ -122,7 +124,7 @@ valohai-papi==0.1.3
     # via valohai-utils
 valohai-utils==0.1.12
     # via valohai-cli
-valohai-yaml==0.20.1
+valohai-yaml==0.21.0
     # via
     #   valohai-cli
     #   valohai-papi

--- a/source/_templates/_valohai_feedback.html
+++ b/source/_templates/_valohai_feedback.html
@@ -1,0 +1,32 @@
+<div class="toc-title-container">
+  <span class="toc-title">
+    {{ _("Was this useful?") }}
+  </span>
+</div>
+<div class="toc-tree-container">
+  <div class="toc-tree">
+    <ul>
+      <li>
+        <span>
+          <a href="#" onclick="javascript:feedback(1)">Yes &#x1F44D;</a> |
+          <a href="#" onclick="javascript:feedback(-1)">No &#x1F44E;</a>
+        </span>
+      </li>
+      <li><br/></li>
+      <li>
+        <a href="https://github.com/valohai/docs/issues/new?title=Feedback%20on%20{{ title|striptags|e }}&body=**Page:**%20{{ html_baseurl }}{{ pagename }}.html%0A%0A**Feedback:**"
+           class="btn btn-neutral" title="Give Feedback" rel="Give Feedback" target="_blank">&#x1F41B; Report an issue</a>
+      </li>
+    </ul>
+  </div>
+</div>
+<script type="text/javascript">
+  function feedback(vote) {
+    gtag(
+      'event', 'Vote', {
+        'event_category': 'Feedback',
+        'event_label': '{{ title|striptags|e }}',
+        'value': vote.toString()
+      });
+  }
+</script>

--- a/source/_templates/_valohai_gtag.html
+++ b/source/_templates/_valohai_gtag.html
@@ -1,0 +1,13 @@
+{#- Global site tag (gtag.js) - Google Analytics -#}
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-87958940-3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+
+  gtag('js', new Date());
+
+  gtag('config', 'UA-87958940-3');
+</script>

--- a/source/_templates/_valohai_gtag_track.js
+++ b/source/_templates/_valohai_gtag_track.js
@@ -1,0 +1,9 @@
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+dataLayer.push(arguments);
+}
+
+gtag('js', new Date());
+
+gtag('config', 'UA-87958940-3');

--- a/source/_templates/base.html
+++ b/source/_templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js">
+<html class="no-js"{% if language is not none %} lang="{{ language }}"{% endif %}>
   <head>
     {%- block site_meta -%}
     <meta charset="utf-8"/>
@@ -30,8 +30,8 @@
     {%- endblock linktags %}
 
     {# Favicon #}
-    {%- if favicon -%}
-      <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
+    {%- if favicon_url -%}
+      <link rel="shortcut icon" href="{{ favicon_url }}"/>
     {%- endif -%}
 
     {#- Generator banner -#}
@@ -50,23 +50,23 @@
 
     {%- block styles -%}
 
-    {#- Theme-related stylesheets -#}
-    {%- block theme_styles -%}
-    <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}">
-    <link media="(prefers-color-scheme: dark)" rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', 1) }}">
-    {% include "partials/_head_css_variables.html" with context %}
-    {%- endblock -%}
-
     {# Custom stylesheets #}
     {%- block regular_styles -%}
-    {%- for path in css_files -%}
-    {% if not path.filename.startswith("pygments_dark") -%}
-      {{ css_tag(path) }}
-    {%- endif %}
+    {%- for css in css_files -%}
+      {% if css|attr("filename") -%}
+        {{ css_tag(css) }}
+      {%- else -%}
+        <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
+      {%- endif %}
     {% endfor -%}
     {%- endblock regular_styles -%}
 
-    {%- block extra_styles -%}
+    {#- Theme-related stylesheets -#}
+    {%- block theme_styles %}
+    {% include "partials/_head_css_variables.html" with context %}
+    {%- endblock -%}
+
+    {%- block extra_styles %}
     {%- endblock -%}
 
     {%- endblock styles -%}
@@ -74,29 +74,20 @@
     {#- Custom front matter #}
     {%- block extrahead -%}{%- endblock -%}
 
-        
     {#- Global site tag (gtag.js) - Google Analytics -#}
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-87958940-3"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-87958940-3');
-    </script>
-
+    {% include "_valohai_gtag.html" %}
   </head>
-  <body dir="{{ direction }}">
+  <body>
+    <script>
+      document.body.dataset.theme = localStorage.getItem("theme") || "auto";
+      {% include "_valohai_gtag_track.js" %}
+    </script>
     {% block body %}{% endblock %}
 
     {%- block scripts -%}
 
     {# Custom JS #}
     {%- block regular_scripts -%}
-    {%- set url_root = pathto('', 1) %}
-    {# URL root should never be #, then all links are fragments #}
-    {%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
-    <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
     {% for path in script_files -%}
       {{ js_tag(path) }}
     {% endfor -%}

--- a/source/_templates/base.html
+++ b/source/_templates/base.html
@@ -52,7 +52,6 @@
 
     {#- Theme-related stylesheets -#}
     {%- block theme_styles -%}
-    <link rel="stylesheet" href="{{ pathto(furo_assets['style'], 1) }}">
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}">
     <link media="(prefers-color-scheme: dark)" rel="stylesheet" href="{{ pathto('_static/pygments_dark.css', 1) }}">
     {% include "partials/_head_css_variables.html" with context %}
@@ -68,7 +67,6 @@
     {%- endblock regular_styles -%}
 
     {%- block extra_styles -%}
-    <link rel="stylesheet" href="{{ pathto(furo_assets['furo-extensions.css'], 1) }}">
     {%- endblock -%}
 
     {%- endblock styles -%}
@@ -106,7 +104,6 @@
 
     {# Theme-related JavaScript code #}
     {%- block theme_scripts -%}
-    <script src="{{ pathto(furo_assets['main.js'], 1) }}"></script>
     {%- endblock -%}
 
     {%- endblock scripts -%}

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -1,172 +1,200 @@
 {% extends "base.html" %}
 
 {% block body -%}
-{% include "partials/icons.html" %}
+  {% include "partials/icons.html" %}
 
-<input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation">
-<input type="checkbox" class="sidebar-toggle" name="__toc" id="__toc">
-<label class="overlay sidebar-overlay" for="__navigation"></label>
-<label class="overlay toc-overlay" for="__toc"></label>
+  <input type="checkbox" class="sidebar-toggle" name="__navigation" id="__navigation">
+  <input type="checkbox" class="sidebar-toggle" name="__toc" id="__toc">
+  <label class="overlay sidebar-overlay" for="__navigation">
+    <div class="visually-hidden">Hide navigation sidebar</div>
+  </label>
+  <label class="overlay toc-overlay" for="__toc">
+    <div class="visually-hidden">Hide table of contents sidebar</div>
+  </label>
 
-{% if theme_announcement -%}
-<div class="announcement">
-    <aside class="announcement-content">
+  {% if theme_announcement -%}
+    <div class="announcement">
+      <aside class="announcement-content">
         {% block announcement %} {{ theme_announcement }} {% endblock announcement %}
-    </aside>
-</div>
-{%- endif %}
+      </aside>
+    </div>
+  {%- endif %}
 
-<div class="page">
+  <div class="page">
     <header class="mobile-header">
-        <div class="header-left">
-            <label class="nav-overlay-icon" for="__navigation">
-                <i class="icon"><svg>
-                        <use href="#svg-menu"></use>
-                    </svg></i>
-            </label>
+      <div class="header-left">
+        <label class="nav-overlay-icon" for="__navigation">
+          <div class="visually-hidden">Toggle site navigation sidebar</div>
+          <i class="icon">
+            <svg>
+              <use href="#svg-menu"></use>
+            </svg>
+          </i>
+        </label>
+      </div>
+      <div class="header-center">
+        <a href="{{ pathto(master_doc) }}">
+          <div class="brand">{{ docstitle if docstitle else project }}</div>
+        </a>
+      </div>
+      <div class="header-right">
+        <div class="theme-toggle-container theme-toggle-header">
+          <button class="theme-toggle">
+            <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
+            <svg class="theme-icon-when-auto">
+              <use href="#svg-sun-half"></use>
+            </svg>
+            <svg class="theme-icon-when-dark">
+              <use href="#svg-moon"></use>
+            </svg>
+            <svg class="theme-icon-when-light">
+              <use href="#svg-sun"></use>
+            </svg>
+          </button>
         </div>
-        <div class="header-center">
-            <a href="{{ pathto(master_doc) }}">
-                <div class="brand">{{ docstitle }}</div>
-            </a>
-        </div>
-        <div class="header-right">
-            <label class="toc-overlay-icon toc-header-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
-                <i class="icon"><svg>
-                        <use href="#svg-toc"></use>
-                    </svg></i>
-            </label>
-        </div>
+        <label class="toc-overlay-icon toc-header-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
+          <div class="visually-hidden">Toggle table of contents sidebar</div>
+          <i class="icon">
+            <svg>
+              <use href="#svg-toc"></use>
+            </svg>
+          </i>
+        </label>
+      </div>
     </header>
     <aside class="sidebar-drawer">
-        <div class="sidebar-container">
-            {% block left_sidebar %}
-            <div class="sidebar-sticky">
-                {%- for sidebar_section in sidebars %}
-                {%- include sidebar_section %}
-                {%- endfor %}
-            </div>
-            {% endblock left_sidebar %}
-        </div>
+      <div class="sidebar-container">
+        {% block left_sidebar %}
+          <div class="sidebar-sticky">
+            {%- for sidebar_section in sidebars %}
+              {%- include sidebar_section %}
+            {%- endfor %}
+          </div>
+        {% endblock left_sidebar %}
+      </div>
     </aside>
-    <main class="main">
-        <div class="content">
-            <article role="main">
-                <label class="toc-overlay-icon toc-content-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
-                    <i class="icon"><svg>
-                            <use href="#svg-toc"></use>
-                        </svg></i>
-                </label>
-                {% block content %}{{ body }}{% endblock %}
-                <div style="text-align:center;margin-top:25px;">
+    <div class="main">
+      <div class="content">
+        <div class="article-container">
+          <div class="content-icon-container">
+            <div class="theme-toggle-container theme-toggle-content">
+              <button class="theme-toggle">
+                <div class="visually-hidden">Toggle Light / Dark / Auto color theme</div>
+                <svg class="theme-icon-when-auto">
+                  <use href="#svg-sun-half"></use>
+                </svg>
+                <svg class="theme-icon-when-dark">
+                  <use href="#svg-moon"></use>
+                </svg>
+                <svg class="theme-icon-when-light">
+                  <use href="#svg-sun"></use>
+                </svg>
+              </button>
             </div>
-            </article>
-            <footer>
-                {% block footer %}
-                <div class="related-pages">
-                    {% if next -%}
-                    <a class="next-page" href="{{ next.link }}">
-                        <div class="page-info">
-                            <div class="context">
-                                <span>{{ _("Next") }}</span>
-                            </div>
-                            <div class="title">{{ next.title }}</div>
-                        </div>
-                        <svg>
-                            <use href="#svg-arrow-right"></use>
-                        </svg>
-                    </a>
-                    {%- endif %}
-                    {% if prev -%}
-                    <a class="prev-page" href="{{ prev.link }}">
-                        <svg>
-                            <use href="#svg-arrow-right"></use>
-                        </svg>
-                        <div class="page-info">
-                            <div class="context">
-                                <span>{{ _("Previous") }}</span>
-                            </div>
-                            {% if prev.link == pathto(master_doc) %}
-                            <div class="title">{{ _("Home") }}</div>
-                            {% else %}
-                            <div class="title">{{ prev.title }}</div>
-                            {% endif %}
-                        </div>
-                    </a>
-                    {%- endif %}
-                </div>
-
-                <div class="related-information">
-                    {%- if show_copyright %}
-                    {%- if hasdoc('copyright') %}
-                    {% trans path=pathto('copyright'), copyright=copyright|e -%}
-                    <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}.
-                    {%- endtrans %}
-                    {%- else %}
-                    {% trans copyright=copyright|e -%}
-                    Copyright &#169; {{ copyright }}
-                    {%- endtrans %}
-                    {%- endif %}
-                    {%- endif %}
-                    {%- if last_updated %}
-                    |
-                    {% trans last_updated=last_updated|e -%}
-                    Last updated on {{ last_updated }}.
-                    {%- endtrans %}
-                    {%- endif %}
-                </div>
-
-                {% endblock footer %}
-            </footer>
+            <label class="toc-overlay-icon toc-content-icon{% if furo_hide_toc %} no-toc{% endif %}" for="__toc">
+              <div class="visually-hidden">Toggle table of contents sidebar</div>
+              <i class="icon">
+                <svg>
+                  <use href="#svg-toc"></use>
+                </svg>
+              </i>
+            </label>
+          </div>
+          <article role="main">
+            {% block content %}{{ body }}{% endblock %}
+          </article>
         </div>
-        {% if not furo_hide_toc %}
-        <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">
-            {% block right_sidebar %}
-            <div class="toc-sticky toc-scroll">
-                <div class="toc-title-container">
-                    <span class="toc-title">
-                        {{ _("Contents") }}
-                    </span>
-                </div>
-                <div class="toc-tree-container">
-                    <div class="toc-tree">
-                        {{ toc }}
+        <footer>
+          {% block footer %}
+            <div class="related-pages">
+              {% if next -%}
+                <a class="next-page" href="{{ next.link }}">
+                  <div class="page-info">
+                    <div class="context">
+                      <span>{{ _("Next") }}</span>
                     </div>
-                </div>
-                <div class="toc-title-container">
-                    <span class="toc-title">
-                        {{ _("Was this useful?") }}
-                    </span>
-                </div>
-                <div class="toc-tree-container">
-                    <div class="toc-tree">
-                        <ul>
-                            <li><span><a href="#" onclick="javascript:feedback(1)">Yes &#x1F44D;</a> | <a href="#" onclick="javascript:feedback(-1)">No &#x1F44E;</a></span></li>
-                            <li><br /></li>
-                            <li>
-                                <a href="https://github.com/valohai/docs/issues/new?title=Feedback%20on%20{{ title|striptags|e }}&body=**Page:**%20{{ html_baseurl }}{{ pagename }}.html%0A%0A**Feedback:**"
-                                    class="btn btn-neutral" title="Give Feedback" rel="Give Feedback" target="_blank">&#x1F41B; Report an issue</a>
-                            </li>
-                        </ul>
+                    <div class="title">{{ next.title }}</div>
+                  </div>
+                  <svg>
+                    <use href="#svg-arrow-right"></use>
+                  </svg>
+                </a>
+              {%- endif %}
+              {% if prev -%}
+                <a class="prev-page" href="{{ prev.link }}">
+                  <svg>
+                    <use href="#svg-arrow-right"></use>
+                  </svg>
+                  <div class="page-info">
+                    <div class="context">
+                      <span>{{ _("Previous") }}</span>
                     </div>
-                </div>
+                    {% if prev.link == pathto(master_doc) %}
+                      <div class="title">{{ _("Home") }}</div>
+                    {% else %}
+                      <div class="title">{{ prev.title }}</div>
+                    {% endif %}
+                  </div>
+                </a>
+              {%- endif %}
             </div>
-            {% endblock right_sidebar %}
-        </aside>
-        {% endif %}
-    </main>
-</div>
-<script type="text/javascript">
 
-function feedback(vote) {
-    gtag(
-        'event', 'Vote', {
-        'event_category': 'Feedback',
-        'event_label': '{{ title|striptags|e }}',
-        'value': vote.toString()
-    });
-}
-
-
-</script>
+            <div class="related-information">
+              {%- if show_copyright %}
+                {%- if hasdoc('copyright') %}
+                  {% trans path=pathto('copyright'), copyright=copyright|e -%}
+                    <a href="{{ path }}">Copyright</a> &#169; {{ copyright }}.
+                  {%- endtrans %}
+                {%- else %}
+                  {% trans copyright=copyright|e -%}
+                    Copyright &#169; {{ copyright }}
+                  {%- endtrans %}
+                {%- endif %}
+              {%- endif %}
+              {%- if last_updated %}
+                {%- if show_copyright %} | {%- endif %}
+                {% trans last_updated=last_updated|e -%}
+                  Last updated on {{ last_updated }}.
+                {%- endtrans %}
+              {%- endif %}
+              {%- if show_copyright or last_updated %} | {%- endif %}
+              {% trans %}Created using {% endtrans -%}
+              {%- if show_sphinx -%}
+                {% trans %}<a href="https://www.sphinx-doc.org/">Sphinx</a> and {% endtrans -%}
+              {% endif -%}
+              {%- trans -%}
+                <a class="muted-link" href="https://pradyunsg.me">@pradyunsg</a>'s
+                <a href="https://github.com/pradyunsg/furo">Furo theme</a>.
+              {%- endtrans %}
+              {%- if show_source and has_source and sourcename %}
+                | <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
+                     rel="nofollow">
+                {{ _('Show Source') }}
+              </a>
+              {%- endif %}
+            </div>
+          {% endblock footer %}
+        </footer>
+      </div>
+      <aside class="toc-drawer{% if furo_hide_toc %} no-toc{% endif %}">
+        {% block right_sidebar %}
+          {% if not furo_hide_toc %}
+            <div class="toc-sticky toc-scroll">
+              <div class="toc-title-container">
+                <span class="toc-title">
+                  {{ _("Contents") }}
+                </span>
+              </div>
+              <div class="toc-tree-container">
+                <div class="toc-tree">
+                  {{ toc }}
+                </div>
+              </div>
+              {% include "_valohai_feedback.html" %}
+            </div>
+          {% endif %}
+        {% endblock right_sidebar %}
+      </aside>
+    </div>
+  </div>
 {%- endblock %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -52,6 +52,7 @@ html_logo = 'favicon.ico'
 html_theme = 'furo'
 html_theme_path = ['_themes']
 html_static_path = ['_static']
+html_show_sourcelink = False
 html_theme_options = {
 
     "light_css_variables": {


### PR DESCRIPTION
This PR:

* unpins Furo to bump it to 2021.11
* updates Sphinx to 4.x (since Furo was holding it back) which is compatible with Python 3.10
* merges in template changes from Furo's base.html and page.html (which had been vendored in and overridden here).
  * I moved the Valohai specific bits into `{% include %}`able fragments, so merging in future changes should be easier. 

With all of this, the diff between `master`'s `make html` output to this branch's `make html` output is pretty minimal.