### PR TITLE
Configure auto-assign-action for PRs

### DIFF
--- a/.github/actions/pr-auto-assign.yml
+++ b/.github/actions/pr-auto-assign.yml
@@ -1,0 +1,14 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.1

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,6 @@
+addReviewers: true
+reviewers:
+  - DrazenDodik
+  - noorula
+skipKeywords:
+  - wip


### PR DESCRIPTION
I guess we'll only ever find out if this works in a subsequent PR. 😄 

The action is https://github.com/kentaro-m/auto-assign-action/